### PR TITLE
Fix latest link

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -37,7 +37,7 @@ module.exports = function * () {
   // header files
   console.log(`[${pkg.name}] Start download headers.`)
 
-  yield utils.download(`https://nodejs.org/dist/latest/node-v${version}-headers.tar.gz`, dest, 'headers.tar.gz')
+  yield utils.download(`https://nodejs.org/dist/v${version}/node-v${version}-headers.tar.gz`, dest, 'headers.tar.gz')
 
   // shared library
   console.log(`[${pkg.name}] Start download library.`)


### PR DESCRIPTION
I tried the `lockjs install` but got 404 error, because the latest nodejs is v.6.6.0, but `nodejs-latest` lib is not up-to-date, and give v6.5.0. So I changed the `latest` to `${version}` in download link to fix this issue.